### PR TITLE
Enable pluggable listeners for offline changes

### DIFF
--- a/packages/offix-client/src/OfflineApolloClient.ts
+++ b/packages/offix-client/src/OfflineApolloClient.ts
@@ -1,0 +1,24 @@
+import {  NormalizedCacheObject } from "apollo-cache-inmemory";
+import { ApolloClient } from "apollo-client";
+import { OfflineStore, OfflineQueueListener } from "./offline";
+
+/**
+ * Extension to ApolloClient providing additional capabilities.
+ *
+ * @see ApolloClient
+ */
+export interface ApolloOfflineClient extends ApolloClient<NormalizedCacheObject> {
+  /**
+   * Store that can be used to retrieve offline changes
+   * Developers can use it to visualize offline changes in their application
+   */
+  offlineStore: OfflineStore;
+
+  /**
+   * Allows to register offline queue listener
+   * to listen for various changes in queue
+   *
+   * @param listener
+   */
+  registerOfflineEventListener(listener: OfflineQueueListener): void;
+}

--- a/packages/offix-client/src/config/DataSyncConfig.ts
+++ b/packages/offix-client/src/config/DataSyncConfig.ts
@@ -86,6 +86,8 @@ export interface DataSyncConfig {
 
   /**
    * Interface that can be implemented to receive information about the data conflict
+   *
+   * @deprecated see OfflineClient.registerOfflineEventListener
    */
   conflictListener?: ConflictListener;
 

--- a/packages/offix-client/src/index.ts
+++ b/packages/offix-client/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./OfflineClient";
+export * from "./OfflineApolloClient";
 export * from "./config";
 export * from "./conflicts";
 export * from "./links";

--- a/packages/offix-client/src/offline/OfflineMutationsHandler.ts
+++ b/packages/offix-client/src/offline/OfflineMutationsHandler.ts
@@ -18,14 +18,12 @@ export const logger = debug.default(MUTATION_QUEUE_LOGGER);
 // TODO rename
 export class OfflineMutationsHandler {
 
-  private apolloClient: ApolloClient<NormalizedCacheObject>;
-  private store: OfflineStore;
   private mutationCacheUpdates?: CacheUpdates;
 
-  constructor(apolloClient: ApolloClient<NormalizedCacheObject>, clientConfig: DataSyncConfig) {
-    this.apolloClient = apolloClient;
+  constructor(private store: OfflineStore,
+              private apolloClient: ApolloClient<NormalizedCacheObject>,
+              clientConfig: DataSyncConfig) {
     this.mutationCacheUpdates = clientConfig.mutationCacheUpdates;
-    this.store = new OfflineStore(clientConfig);
   }
 
   /**

--- a/packages/offix-client/src/offline/OfflineQueue.ts
+++ b/packages/offix-client/src/offline/OfflineQueue.ts
@@ -1,5 +1,5 @@
 import { OperationQueueEntry } from "./OperationQueueEntry";
-import { OfflineQueueListener } from "./OfflineQueueListener";
+import { OfflineQueueListener } from "./events/OfflineQueueListener";
 import { isClientGeneratedId } from "../cache/createOptimisticResponse";
 import { ObjectState } from "../conflicts/ObjectState";
 import { Operation, NextLink, Observable, FetchResult } from "apollo-link";

--- a/packages/offix-client/src/offline/events/CompositeQueueListener.ts
+++ b/packages/offix-client/src/offline/events/CompositeQueueListener.ts
@@ -1,0 +1,64 @@
+import { ListenerProvider } from "./ListenerProvider";
+import { OfflineQueueListener } from "./OfflineQueueListener";
+import { FetchResult, Operation } from "apollo-link";
+import { OperationQueueEntry } from "../OperationQueueEntry";
+
+/***
+ * Wraps multiple listeners allowing them to be
+ * registered and unregistered dynamically.
+ */
+export class CompositeQueueListener implements OfflineQueueListener {
+
+  /**
+   * @param listenerProvider instance that contains all registered providers
+   */
+  constructor(private listenerProvider: ListenerProvider) {
+  }
+
+  /**
+  * Called when new operation is being added to offline queue
+  */
+  public onOperationEnqueued(operation: OperationQueueEntry) {
+    this.listenerProvider.queueListeners.forEach((listener) => {
+      if (listener.onOperationEnqueued) {
+        listener.onOperationEnqueued(operation);
+      }
+    });
+  }
+
+  /**
+   * Called when back online and operation succeeds
+   */
+  public onOperationSuccess(operation: Operation, result: FetchResult) {
+    this.listenerProvider.queueListeners.forEach((listener) => {
+      if (listener.onOperationSuccess) {
+        listener.onOperationSuccess(operation, result);
+      }
+    });
+  }
+
+  /**
+   * Called when back online and operation fails with GraphQL error
+   *
+   * graphQLError - application error (it means that user need to react to error and sent this operation again)
+   * networkError - operation was retried but it did not reached server (it will be reatempted again)
+   */
+  public onOperationFailure(operation: Operation, graphQLError?: any, networkError?: any) {
+    this.listenerProvider.queueListeners.forEach((listener) => {
+      if (listener.onOperationFailure) {
+        listener.onOperationFailure(operation, graphQLError, networkError);
+      }
+    });
+  }
+
+  /**
+   * Called when offline operation queue is cleared
+   */
+  public queueCleared() {
+    this.listenerProvider.queueListeners.forEach((listener) => {
+      if (listener.queueCleared) {
+        listener.queueCleared();
+      }
+    });
+  }
+}

--- a/packages/offix-client/src/offline/events/ListenerProvider.ts
+++ b/packages/offix-client/src/offline/events/ListenerProvider.ts
@@ -1,0 +1,5 @@
+import { OfflineQueueListener } from "./OfflineQueueListener";
+
+export interface ListenerProvider {
+  queueListeners: OfflineQueueListener[];
+}

--- a/packages/offix-client/src/offline/events/OfflineQueueListener.ts
+++ b/packages/offix-client/src/offline/events/OfflineQueueListener.ts
@@ -1,5 +1,5 @@
 import { FetchResult, Operation } from "apollo-link";
-import { OperationQueueEntry } from "./OperationQueueEntry";
+import { OperationQueueEntry } from "../OperationQueueEntry";
 
 /**
  * Interface for creating listeners for offline queue.

--- a/packages/offix-client/src/offline/index.ts
+++ b/packages/offix-client/src/offline/index.ts
@@ -1,6 +1,6 @@
 export * from "./network/NetworkStatus";
 export * from "./network/WebNetworkStatus";
 export * from "./network/CordovaNetworkStatus";
-export * from "./OfflineQueueListener";
+export * from "./events/OfflineQueueListener";
 export * from "./OfflineMutationsHandler";
 export * from "./OfflineStore";

--- a/packages/offix-client/test/OfflineClientTest.ts
+++ b/packages/offix-client/test/OfflineClientTest.ts
@@ -3,6 +3,7 @@ import { expect, should } from "chai";
 import { mock } from "fetch-mock";
 import { storage } from "./mock/Storage";
 import { networkStatus } from "./mock/NetworkState";
+import { CompositeQueueListener } from "../src/offline/events/CompositeQueueListener";
 
 const url = "http://test";
 
@@ -12,13 +13,22 @@ describe("Top level api tests", () => {
   });
   it("check old api", async () => {
     const client = await createClient({
-      httpUrl: url, storage, networkStatus});
-    should().exist(client.offlineStore);
+      httpUrl: url, storage, networkStatus
+    });
+    should().exist(client);
   });
 
   it("check new api", async () => {
     const client = new OfflineClient({ httpUrl: url, storage, networkStatus });
     const initClient = await client.init();
     should().exist(initClient.offlineStore);
+    should().exist(client.registerOfflineEventListener);
+  });
+
+  it("Apply listener", async () => {
+    const client = new OfflineClient({ httpUrl: url, storage, networkStatus });
+    const initClient = await client.init();
+    initClient.registerOfflineEventListener(
+      new CompositeQueueListener({ queueListeners: [] }));
   });
 });


### PR DESCRIPTION
## Motivation

Allow registering multiple listeners for detecting offline queue changes like an item added etc. Additionally, we will be enabling registering listeners on the fly as opposed to the one single startup listener