### PR TITLE
feat: support multiple queries, export functions

### DIFF
--- a/packages/offix-client/package.json
+++ b/packages/offix-client/package.json
@@ -48,7 +48,8 @@
     "graphql": "14.2.1",
     "graphql-tag": "2.10.1",
     "graphql-tools": "4.0.4",
-    "subscriptions-transport-ws": "0.9.16"
+    "subscriptions-transport-ws": "0.9.16",
+    "util": "^0.12.0"
   },
   "gitHead": "c52429fc496cfdbaaf06fd55a509f14b12c7ce1c"
 }

--- a/packages/offix-client/src/cache/createSubscriptionOptions.ts
+++ b/packages/offix-client/src/cache/createSubscriptionOptions.ts
@@ -11,6 +11,11 @@ export interface SubscriptionHelperOptions {
   idField?: string;
 }
 
+/**
+ * Helper function which can be used to call subscribeToMore for multiple SubscriptionHelperOptions
+ * @param observableQuery the query which you would like to call subscribeToMore on.
+ * @param arrayOfHelperOptions the array of `SubscriptionHelperOptions`
+ */
 export const subscribeToMoreHelper = (observableQuery: ObservableQuery,
                                       arrayOfHelperOptions: SubscriptionHelperOptions[]) => {
   for (const option of arrayOfHelperOptions) {
@@ -18,6 +23,11 @@ export const subscribeToMoreHelper = (observableQuery: ObservableQuery,
   }
 };
 
+/**
+ * Creates a SubscribeToMoreOptions object which can be used with Apollo Client's subscribeToMore function
+ * on an observable query.
+ * @param options see `SubscriptionHelperOptions`
+ */
 export const createSubscriptionOptions = (options: SubscriptionHelperOptions): SubscribeToMoreOptions => {
   const {
     subscriptionQuery,
@@ -53,6 +63,11 @@ export const createSubscriptionOptions = (options: SubscriptionHelperOptions): S
   };
 };
 
+/**
+ * Generate the standard update function to update the cache for a given operation type and query.
+ * @param opType The type of operation being performed
+ * @param idField The id field the item keys off
+ */
 export const getUpdateQueryFunction = (opType: CacheOperation, idField = "id"): UpdateFunction => {
   let updateFunction: UpdateFunction;
 

--- a/packages/offix-client/test/mock/mutations.ts
+++ b/packages/offix-client/test/mock/mutations.ts
@@ -8,6 +8,14 @@ mutation createItem($title: String!){
   }
 `;
 
+export const CREATE_LIST = gql`
+mutation createList($title: String!){
+    createList(title: $title){
+      title
+    }
+  }
+`;
+
 export const DELETE_ITEM = gql`
 mutation deleteItem($id: ID!){
     deleteItem(id: $id){
@@ -16,9 +24,35 @@ mutation deleteItem($id: ID!){
   }
 `;
 
+export const DOESNT_EXIST = gql`
+mutation somethingFake($id: ID!){
+    somethingFake(id: $id){
+      title
+    }
+  }
+`;
+
 export const GET_ITEMS = gql`
   query allItems($first: Int) {
     allItems(first: $first) {
+      id
+      title
+    }
+}
+`;
+
+export const GET_LISTS = gql`
+  query allLists($first: Int) {
+    allLists(first: $first) {
+      id
+      title
+    }
+}
+`;
+
+export const GET_NON_EXISTENT = gql`
+  query somethingFake($first: Int) {
+    somethingFake(first: $first) {
       id
       title
     }


### PR DESCRIPTION
### Description

This PR provides the ability to update multiple queries in the cache when a mutation is run.

It also exports valuable functions the client may want to use without using the full cache helper function.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [ ] documentation is changed or added
