### PR TITLE
Fix to not create optimistic response when no returnType is passed

### DIFF
--- a/packages/offix-cache/src/cache/mutations.ts
+++ b/packages/offix-cache/src/cache/mutations.ts
@@ -28,14 +28,16 @@ export const createMutationOptions = (options: MutationHelperOptions): MutationO
     context
   } = options;
   const operationName = getOperationFieldName(mutation);
-  const optimisticResponse = createOptimisticResponse({
-    mutation,
-    variables,
-    updateQuery,
-    returnType,
-    operationType,
-    idField
-  });
+  if (returnType && !options.optimisticResponse) {
+    options.optimisticResponse = createOptimisticResponse({
+      mutation,
+      variables,
+      updateQuery,
+      returnType,
+      operationType,
+      idField
+    });
+  }
 
   const update: MutationUpdaterFn = (cache, { data }) => {
     if (isArray(updateQuery)) {
@@ -48,8 +50,7 @@ export const createMutationOptions = (options: MutationHelperOptions): MutationO
       updateFunction(cache, { data });
     }
   };
-
-  return { ...options, optimisticResponse, update, context: {...context, returnType} };
+  return { ...options, update, context: {...context, returnType} };
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

Currently returnType is optional but we always try to build an optimistic response regardless of whether or not it is provided. We should not build one if we don't get a returnType.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
